### PR TITLE
Correct normalize for moving direction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+checkpoints/
+tmp/

--- a/drag_gan.py
+++ b/drag_gan.py
@@ -186,7 +186,7 @@ def drag_gan(g_ema, latent: torch.Tensor, noise, F, handle_points, target_points
             loss = 0
             for i in range(n):
                 pi, ti = handle_points[i], target_points[i]
-                di = (ti - pi) / torch.sum((ti - pi)**2)
+                di = (ti - pi) / (ti - pi).norm()
 
                 for qi in neighbor(int(pi[0]), int(pi[1]), r1):
                     # f1 = F[..., int(qi[0]), int(qi[1])]


### PR DESCRIPTION
The original code for normalizing d_i seems wrong, which makes the length of d_i small.

Also, ignore the `checkpoint` and `tmp` dir.